### PR TITLE
Basic dockerization

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,18 @@
+services:
+  base:
+    profiles: [none]
+    image: ghcr.io/deanayalon/free-admin-dashboard-fork
+    build: .
+    container_name: free-admin-dashboard
+    hostname: free-admin-dashboard
+
+  standalone:
+    extends: base
+    ports:
+      - 5173:5173
+
+  dev:
+    extends: standalone
+    volumes:
+      - .:/app
+  

--- a/dockerfile
+++ b/dockerfile
@@ -11,4 +11,4 @@ RUN npm i
 EXPOSE 5173
 
 ENTRYPOINT [ "npm", "run" ]
-CMD [ "dev" ]
+CMD [ "dev:docker" ]

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,14 @@
+FROM node:19-bullseye
+
+LABEL org.opencontainers.image.source https://github.com/Kuzma02/free-admin-dashboard
+
+WORKDIR /app
+
+COPY . . 
+
+RUN npm i 
+
+EXPOSE 5173
+
+ENTRYPOINT [ "npm", "run" ]
+CMD [ "dev" ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",  // This runs Vite in the normal local dev mode
-    "dev:docker": "vite --host 0.0.0.0",  // This is for Docker, where it listens on all network interfaces
+    "dev": "vite",
+    "dev:docker": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
+    "dev": "vite",  // This runs Vite in the normal local dev mode
+    "dev:docker": "vite --host 0.0.0.0",  // This is for Docker, where it listens on all network interfaces
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
This application is rather simple to containerize, so I went ahead and done it, as per issue #3 

The image is not necessarily slim, and can probably be reduced, but it suits the project's needs

# Current configuration
## Dockerfile
- The docker image used is node:19-bullseye
- it copies the repository files into `/app` and installs the dependencies into the image
- The entrypoint is set to `npm run`
- The default command is `dev`, resulting in `npm run dev`

> Once you build the image and push it to Docker Hub, users will not have to build the image or even clone the repository, just pull it from your repository!

## Docker Compose
When using Docker Compose, I have separated the app into three alternate services:
- **base**: The base service contains the image and build instructions to run the app
  > The image is currently called `ghcr.io/deanayalon/free-admin-dashboard-fork`, see [image name](#image-name)
- **standalone**: Maps port 5173 to the host machine, if not used with a proxy - Not secure, but valid for local use
- **dev**: Mounts the project's files into the container, to reflect changes in real time, for simpler development

### Use
```sh
docker compose up -d standalone # Run the app locally
docker compose up -d dev        # Run the app in development mode (project mount)
```
> When using a reverse-proxy, simply use the `base` service. 

## Image Name
The image is currently named `ghcr.io/deanayalon/free-admin-dashboard-fork`, it is pushed to my GitHub account. You can pull it and use the app immediately without ever cloning the repository by doing:
```sh
docker run -p 5173:5173 ghcr.io/deanayalon/free-admin-dashboard-fork
```

**You can use `ghcr.io/Kuzma02/Free-Admin-Dashboard` as the image name, and it will autoamtically be linked with your GitHub repository!**

## Package.json
Modified `npm run dev` to execute `vite --host 0.0.0.0`, so the container listens on all addresses